### PR TITLE
Add .NET Standard 2.0 compatibility

### DIFF
--- a/CQL.Tests/CQL.Tests.csproj
+++ b/CQL.Tests/CQL.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <AssemblyName>CQL.Tests</AssemblyName>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/CQL.Tests/CQL.Tests.csproj
+++ b/CQL.Tests/CQL.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,10 +38,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime">
-      <HintPath>..\packages\Antlr4.Runtime.4.6.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -72,9 +67,6 @@
       <Name>CQL</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>
@@ -95,14 +87,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props'))" />
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets'))" />
-  </Target>
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CQL.Tests/CQL.Tests.csproj
+++ b/CQL.Tests/CQL.Tests.csproj
@@ -1,97 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1D669631-D619-42F9-962E-CB4CC4A31616}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CQL.Tests</RootNamespace>
+    <TargetFrameworks>net46</TargetFrameworks>
     <AssemblyName>CQL.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <Version>0.1.2</Version>
+    <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  
   <ItemGroup>
-    <Compile Include="EvaluationTests.cs" />
-    <Compile Include="ParserTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TypeSystemBuilderByAttributesTests.cs" />
-    <Compile Include="ValidationTests.cs" />
+    <ProjectReference Include="..\CQL\CQL.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CQL\CQL.csproj">
-      <Project>{e07e2313-aa23-4498-afec-28e2b7c6fd33}</Project>
-      <Name>CQL</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/CQL.Tests/CQL.Tests.csproj
+++ b/CQL.Tests/CQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <AssemblyName>CQL.Tests</AssemblyName>
     <Version>0.1.2</Version>
     <IsPackable>false</IsPackable>

--- a/CQL.Tests/ParserTests.cs
+++ b/CQL.Tests/ParserTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CQL.SyntaxTree;
-using Antlr4.Runtime;
 
 namespace CQL.Tests
 {

--- a/CQL.Tests/Properties/AssemblyInfo.cs
+++ b/CQL.Tests/Properties/AssemblyInfo.cs
@@ -1,36 +1,9 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CQL.Tests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CQL.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1d669631-d619-42f9-962e-cb4cc4a31616")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CQL.Tests/packages.config
+++ b/CQL.Tests/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Antlr4" version="4.6.3" targetFramework="net46" developmentDependency="true" />
-  <package id="Antlr4.CodeGenerator" version="4.6.3" targetFramework="net46" developmentDependency="true" />
-  <package id="Antlr4.Runtime" version="4.6.3" targetFramework="net46" />
-</packages>

--- a/CQL.WPF/CQL.WPF.csproj
+++ b/CQL.WPF/CQL.WPF.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -151,14 +150,6 @@
     <Content Include="Images\variable.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props'))" />
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets'))" />
-  </Target>
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CQL.WPF/CQL.WPF.csproj
+++ b/CQL.WPF/CQL.WPF.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime">
-      <HintPath>..\packages\Antlr4.Runtime.4.6.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.dll</HintPath>

--- a/CQL.WPF/packages.config
+++ b/CQL.WPF/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4" version="4.6.3" targetFramework="net46" developmentDependency="true" />
-  <package id="Antlr4.CodeGenerator" version="4.6.3" targetFramework="net46" developmentDependency="true" />
   <package id="Antlr4.Runtime" version="4.6.3" targetFramework="net46" />
   <package id="AvalonEdit" version="5.0.3" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />

--- a/CQL.WPF/packages.config
+++ b/CQL.WPF/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.6.3" targetFramework="net46" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net46" />
   <package id="AvalonEdit" version="5.0.3" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net46" />

--- a/CQL/CQL.csproj
+++ b/CQL/CQL.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" />
+  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr4.Runtime.4.6.3\lib\net45\Antlr4.Runtime.dll</HintPath>
+      <HintPath>..\packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="QuickGraph, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
@@ -228,12 +228,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.props'))" />
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets'))" />
+    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props'))" />
+    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets'))" />
   </Target>
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.3\build\Antlr4.CodeGenerator.targets')" />
+  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" />
   <PropertyGroup>
     <PostBuildEvent>Powershell.exe -ExecutionPolicy Unrestricted -file "$(SolutionDir)xmldoc2md.ps1" -xml "$(TargetDir)CQL.doc.xml" -xsl "$(SolutionDir)xmldoc2md.xsl" -output "$(SolutionDir)docs\CQL.api.md"</PostBuildEvent>
   </PropertyGroup>

--- a/CQL/CQL.csproj
+++ b/CQL/CQL.csproj
@@ -1,247 +1,102 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E07E2313-AA23-4498-AFEC-28E2B7C6FD33}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CQL</RootNamespace>
+    <TargetFrameworks>net46</TargetFrameworks>
     <AssemblyName>CQL</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <AssemblyTitle>CQL</AssemblyTitle>
+    <PackageId>CQL</PackageId>
+    <Version>0.1.2</Version>
+    <Authors>Markus Rudolph</Authors>
+    <Owners>Markus Rudolph</Owners>
+    <Product>CQL</Product>
+    <Description>CQL is a configurable query language.</Description>
+    <Copyright>Copyright 2018 Markus Rudolph</Copyright>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/Lotes/CQL/master/icon.png</PackageIconUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Configurations>Debug;Release</Configurations>
+    <PackageProjectUrl>https://github.com/Lotes/CQL</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>dsl;query;language;search;filter</PackageTags>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>CQL.doc.xml</DocumentationFile>
-    <WarningsAsErrors>CS1591</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>CQL.doc.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="QuickGraph.Data, Version=3.6.61114.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AutoCompletion\AutoCompletionSuggestor.cs" />
-    <Compile Include="AutoCompletion\Extensions.cs" />
-    <Compile Include="AutoCompletion\IAutoCompletionSuggester.cs" />
-    <Compile Include="AutoCompletion\MyTokenStream.cs" />
-    <Compile Include="AutoCompletion\ParserStack.cs" />
-    <Compile Include="AutoCompletion\Suggestion.cs" />
-    <Compile Include="AutoCompletion\SuggestionType.cs" />
-    <Compile Include="Contexts\IEvaluationScope.cs" />
-    <Compile Include="Contexts\Implementation\EvaluationScope.cs" />
-    <Compile Include="Contexts\Implementation\ValidationScope.cs" />
-    <Compile Include="Contexts\Implementation\VariableDeclaration.cs" />
-    <Compile Include="Contexts\Implementation\VariableDefinition.cs" />
-    <Compile Include="Contexts\IValidationScope.cs" />
-    <Compile Include="Contexts\IVariable.cs" />
-    <Compile Include="Contexts\IVariableDeclaration.cs" />
-    <Compile Include="Contexts\IVariableDefinition.cs" />
-    <Compile Include="Contexts\ScopeExtensions.cs" />
-    <Compile Include="Contexts\ScopeExtensions.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>ScopeExtensions.generated.tt</DependentUpon>
-    </Compile>
-    <Compile Include="Contexts\VariableExtensions.cs" />
-    <Compile Include="EnumerableExtensions.cs" />
-    <Compile Include="HashExtensions.cs" />
-    <Compile Include="ErrorHandling\IErrorListener.cs" />
-    <Compile Include="ErrorHandling\ErrorListener.cs" />
-    <Compile Include="ErrorHandling\LocateableException.cs" />
-    <Compile Include="SyntaxTree\ArrayAccessExpression.cs" />
-    <Compile Include="SyntaxTree\CastExpression.cs" />
-    <Compile Include="SyntaxTree\IdDelimiter.cs" />
-    <Compile Include="SyntaxTree\IExpression.cs" />
-    <Compile Include="SyntaxTree\IntegerLiteralExpression.cs" />
-    <Compile Include="SyntaxTree\IParserLocation.cs" />
-    <Compile Include="SyntaxTree\ISyntaxTreeNode.cs" />
-    <Compile Include="SyntaxTree\MemberExpression.cs" />
-    <Compile Include="SyntaxTree\ParserLocation.cs" />
-    <Compile Include="SyntaxTree\ParserLocationExtensions.cs" />
-    <Compile Include="SyntaxTree\SyntaxTreeExtensions.cs" />
-    <Compile Include="AutoCompletion\Token.cs" />
-    <Compile Include="SyntaxTree\VariableExpression.cs" />
-    <Compile Include="TypeExtensions.cs" />
-    <Compile Include="TypeSystem\CQLGlobalFunction.cs" />
-    <Compile Include="TypeSystem\CQLNativeMemberFunctionAttribute.cs" />
-    <Compile Include="TypeSystem\CQLNativeMemberIndexerAttribute.cs" />
-    <Compile Include="TypeSystem\CQLNativeMemberPropertyAttribute.cs" />
-    <Compile Include="TypeSystem\CQLTypeAttribute.cs" />
-    <Compile Include="TypeSystem\GlobalFunctionSignature.cs" />
-    <Compile Include="TypeSystem\IGlobalFunctionClosure.cs" />
-    <Compile Include="TypeSystem\IMemberFunctionSignature.cs" />
-    <Compile Include="TypeSystem\Implementation\ForeignIndexer.cs" />
-    <Compile Include="TypeSystem\Implementation\ForeignProperty.cs" />
-    <Compile Include="TypeSystem\Implementation\GlobalFunction.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>GlobalFunction.generated.tt</DependentUpon>
-    </Compile>
-    <Compile Include="TypeSystem\Implementation\LambdaGlobalFunction.cs" />
-    <Compile Include="TypeSystem\Implementation\MemberFunction.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>MemberFunction.generated.tt</DependentUpon>
-    </Compile>
-    <Compile Include="TypeSystem\Implementation\NativeGlobalFunction.cs" />
-    <Compile Include="TypeSystem\Implementation\NativeIndexer.cs" />
-    <Compile Include="TypeSystem\Implementation\NativeProperty.cs" />
-    <Compile Include="TypeSystem\Implementation\Type.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Type.generated.tt</DependentUpon>
-    </Compile>
-    <Compile Include="TypeSystem\IType.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>IType.generated.tt</DependentUpon>
-    </Compile>
-    <Compile Include="TypeSystem\SystemDefaultFlags.cs" />
-    <Compile Include="TypeSystem\IGlobalFunction.cs" />
-    <Compile Include="TypeSystem\TypeDefaultFlags.cs" />
-    <Compile Include="TypeSystem\IMemberIndexer.cs" />
-    <Compile Include="TypeSystem\IMemberFunction.cs" />
-    <Compile Include="TypeSystem\IMemberFunctionClosure.cs" />
-    <Compile Include="TypeSystem\Implementation\MemberFunction.cs" />
-    <Compile Include="TypeSystem\Implementation\Type.cs" />
-    <Compile Include="TypeSystem\IProperty.cs" />
-    <Compile Include="TypeSystem\MethodExtensions.cs" />
-    <Compile Include="TypeSystem\TypeSystemBuilderExtensions.cs" />
-    <Compile Include="TypeSystem\UnknownTypeException.cs" />
-    <Compile Include="TypeSystem\BinaryOperation.cs" />
-    <Compile Include="Contexts\IScope.cs" />
-    <Compile Include="TypeSystem\CoercionKind.cs" />
-    <Compile Include="TypeSystem\CoercionRule.cs" />
-    <Compile Include="TypeSystem\Implementation\TypeSystem.cs" />
-    <Compile Include="TypeSystem\Implementation\TypeSystemBuilder.cs" />
-    <Compile Include="TypeSystem\ITypeSystemBuilder.cs" />
-    <Compile Include="TypeSystem\IType.cs" />
-    <Compile Include="TypeSystem\TypeSystemExtensions.cs" />
-    <Compile Include="TypeSystem\UnaryOperation.cs" />
-    <Compile Include="DictionaryExtensions.cs" />
-    <Compile Include="Queries.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StringExtensions.cs" />
-    <Compile Include="SyntaxTree\ArrayExpression.cs" />
-    <Compile Include="SyntaxTree\BinaryOperationExpression.cs" />
-    <Compile Include="SyntaxTree\BinaryOperator.cs" />
-    <Compile Include="SyntaxTree\BooleanLiteralExpression.cs" />
-    <Compile Include="SyntaxTree\ConditionalExpression.cs" />
-    <Compile Include="SyntaxTree\FloatingPointLiteralExpression.cs" />
-    <Compile Include="SyntaxTree\EmptyExpression.cs" />
-    <Compile Include="SyntaxTree\MethodCallExpression.cs" />
-    <Compile Include="SyntaxTree\NullExpression.cs" />
-    <Compile Include="SyntaxTree\ParenthesisExpression.cs" />
-    <Compile Include="SyntaxTree\Query.cs" />
-    <Compile Include="SyntaxTree\StringLiteralExpression.cs" />
-    <Compile Include="SyntaxTree\UnaryOperationExpression.cs" />
-    <Compile Include="SyntaxTree\UnaryOperator.cs" />
-    <Compile Include="TypeSystem\ITypeSystem.cs" />
-    <Compile Include="TypeSystem\AmbigiousTypeException.cs" />
-    <Compile Include="TypeSystem\Void.cs" />
-    <Compile Include="Visitors\ExpressionsVisitor.cs" />
-    <Compile Include="Visitors\ExpressionVisitor.cs" />
-    <Compile Include="Visitors\NameVisitor.cs" />
-    <Compile Include="Visitors\QueryVisitor.cs" />
-  </ItemGroup>
+
   <ItemGroup>
     <Antlr4 Include="CQL.g4">
       <Generator>MSBuild:Compile</Generator>
       <Listener>True</Listener>
       <Visitor>True</Visitor>
     </Antlr4>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
+
   <ItemGroup>
-    <Content Include="Contexts\ScopeExtensions.generated.tt">
+    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Antlr4" Version="4.6.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Antlr4.CodeGenerator" Version="4.6.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Antlr4.Runtime" Version="4.6.6" />
+    <PackageReference Include="QuickGraph" Version="3.6.61119.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+    <None Include="Contexts\ScopeExtensions.generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ScopeExtensions.generated.cs</LastGenOutput>
-    </Content>
-    <Content Include="TypeSystem\Implementation\GlobalFunction.generated.tt">
+    </None>
+    <None Include="TypeSystem\Implementation\GlobalFunction.generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>GlobalFunction.generated.cs</LastGenOutput>
-    </Content>
-    <Content Include="TypeSystem\Implementation\MemberFunction.generated.tt">
+    </None>
+    <None Include="TypeSystem\Implementation\MemberFunction.generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>MemberFunction.generated.cs</LastGenOutput>
-    </Content>
-    <Content Include="TypeSystem\Implementation\Type.generated.tt">
+    </None>
+    <None Include="TypeSystem\Implementation\Type.generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Type.generated.cs</LastGenOutput>
-    </Content>
-    <Content Include="TypeSystem\IType.generated.tt">
+    </None>
+    <None Include="TypeSystem\IType.generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>IType.generated.cs</LastGenOutput>
-    </Content>
+    </None>
   </ItemGroup>
+
   <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Compile Update="Contexts\ScopeExtensions.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ScopeExtensions.generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="TypeSystem\Implementation\GlobalFunction.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GlobalFunction.generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="TypeSystem\Implementation\MemberFunction.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MemberFunction.generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="TypeSystem\Implementation\Type.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Type.generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="TypeSystem\IType.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IType.generated.tt</DependentUpon>
+    </Compile>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props'))" />
-    <Error Condition="!Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets'))" />
-  </Target>
-  <Import Project="..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" />
-  <PropertyGroup>
-    <PostBuildEvent>Powershell.exe -ExecutionPolicy Unrestricted -file "$(SolutionDir)xmldoc2md.ps1" -xml "$(TargetDir)CQL.doc.xml" -xsl "$(SolutionDir)xmldoc2md.xsl" -output "$(SolutionDir)docs\CQL.api.md"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/CQL/CQL.csproj
+++ b/CQL/CQL.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>CQL</AssemblyName>
     <AssemblyTitle>CQL</AssemblyTitle>
     <PackageId>CQL</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
     <Authors>Markus Rudolph</Authors>
     <Owners>Markus Rudolph</Owners>
     <Product>CQL</Product>

--- a/CQL/CQL.csproj
+++ b/CQL/CQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>CQL</AssemblyName>
     <AssemblyTitle>CQL</AssemblyTitle>
     <PackageId>CQL</PackageId>
@@ -46,6 +46,11 @@
     </PackageReference>
     <PackageReference Include="Antlr4.Runtime" Version="4.6.6" />
     <PackageReference Include="QuickGraph" Version="3.6.61119.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="System.CodeDom" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CQL/Properties/AssemblyInfo.cs
+++ b/CQL/Properties/AssemblyInfo.cs
@@ -1,36 +1,10 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CQL")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CQL")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e07e2313-aa23-4498-afec-28e2b7c6fd33")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CQL/packages.config
+++ b/CQL/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4" version="4.6.3" targetFramework="net46" developmentDependency="true" />
-  <package id="Antlr4.CodeGenerator" version="4.6.3" targetFramework="net46" developmentDependency="true" />
-  <package id="Antlr4.Runtime" version="4.6.3" targetFramework="net46" />
+  <package id="Antlr4" version="4.6.6" targetFramework="net46" developmentDependency="true" />
+  <package id="Antlr4.CodeGenerator" version="4.6.6" targetFramework="net46" developmentDependency="true" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net46" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR does a few things to achieve `netstandard2.0` compatibility. The commits lay them out neatly, but in summary:

- Remove unusued `Antlr4` references
- Upgrade `Antlr4`
- Convert to new `.csproj` file format.
- Add `netstandard2.0` target
- Bump versions to 0.2.0

Building the `Release` configuration will automatically generate `.nupkg` file, which should be close to ready to upload to NuGet.